### PR TITLE
Use ocaml-re instead of pcre-ocaml

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -12,7 +12,7 @@ In order to compile this package, you will need:
 * ocaml for all, test main, doc api-expect
 * findlib
 * extlib for library expect
-* pcre for library expect-pcre
+* re for library expect-pcre
 * oUnit for executable test
 
 Installing

--- a/_oasis
+++ b/_oasis
@@ -29,7 +29,7 @@ Library expect
 Library "expect-pcre"
   Path: src
   Modules: ExpectPcre
-  BuildDepends: expect, pcre
+  BuildDepends: expect, re
   FindlibParent: expect
   FindlibName: pcre
 

--- a/src/expectPcre.ml
+++ b/src/expectPcre.ml
@@ -31,9 +31,10 @@ let expect t ?fmatches actions action_default =
              | #expect_match as x ->
                  x
              | `Rex rex ->
-                 `Fun (fun s -> Pcre.pmatch ~rex s)
+                 `Fun (fun s -> Re.Pcre.pmatch ~rex s)
              | `Pat pat ->
-                 `Fun (fun s -> Pcre.pmatch ~pat s)
+                 let rex = Re.Pcre.regexp pat in
+                 `Fun (fun s -> Re.Pcre.pmatch ~rex s)
          in
            exp, a)
       actions

--- a/src/expectPcre.mli
+++ b/src/expectPcre.mli
@@ -48,4 +48,4 @@ val expect :
   ?fmatches:(string -> 'a option) list ->
   ([<Expect.expect_match
     | `Pat of string
-    | `Rex of Pcre.regexp] * 'a) list -> 'a -> 'a
+    | `Rex of Re.Pcre.regexp] * 'a) list -> 'a -> 'a


### PR DESCRIPTION
Rationale: pcre-ocaml depends on an obsolete library:
  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1000004